### PR TITLE
Add type reference to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "1.1.1",
 	"description": "convert csv to object array",
 	"main": "dest/parser.js",
+	"types": "dest/parser.d.ts",
 	"scripts": {
 		"pretsc": "rimraf dest",
 		"tsc": "tsc -p .",


### PR DESCRIPTION
As per https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package , this option should be used since this package provides a "main" .js file. This should allow typescript to automatically use the definitions you have created.